### PR TITLE
 Fix .gitignore ignoring everything that wasn't yet tracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,13 +14,16 @@
 ##########
 # Addons files
 ##########
+# Include the add-ons folder
 !/addons
+# ...but ignore its contents.
+addons/*
 
-# the main plugin
+# Except for the main plugin
 !/addons/dialog_plugin/
 !/addons/dialog_plugin/*
 
-# the unit-test plugin that needs an update
+# And the unit-test plugin that needs an update
 !/addons/WAT/
 !/addons/WAT/*
 !/tests/
@@ -32,7 +35,3 @@
 ##########
 !/docs/
 !/docs/*
-
-
-# But at the end of it all, re-ignore .import files
-*.import

--- a/.gitignore
+++ b/.gitignore
@@ -14,16 +14,25 @@
 ##########
 # Addons files
 ##########
+!/addons
 
 # the main plugin
+!/addons/dialog_plugin/
 !/addons/dialog_plugin/*
 
 # the unit-test plugin that needs an update
+!/addons/WAT/
 !/addons/WAT/*
+!/tests/
 !/tests/*
 
 
 ##########
 # Docs
 ##########
+!/docs/
 !/docs/*
+
+
+# But at the end of it all, re-ignore .import files
+*.import


### PR DESCRIPTION
Currently, any additions to the repo will not be seen, even if it's in supposedly tracked folders - this is because the .gitignore wildcards are ignored due to its current set up. For example:

```
# Ignores everything
/*
# Except:
# the main plugin
!/addons/dialog_plugin/*
```

Will fail, because dialog_plugin is an ignored folder.
The solution is:

```
# Ignores everything
/*
# Except:
# the main plugin
!/addons/dialog_plugin/
!/addons/dialog_plugin/*
```

making the folder and the wild card both work. From what I understand, order matters. The folder has to be excepted FIRST, and the wild card added SECOND.
At the very least, the order matters if you want to make exceptions to exceptions - like I did by making it so .import files are not included regardless.