### PR TITLE
Fix random missing options (#54)

### DIFF
--- a/addons/textalog/nodes/dialogue_base_node/options_node/options_node.gd
+++ b/addons/textalog/nodes/dialogue_base_node/options_node/options_node.gd
@@ -14,12 +14,12 @@ func add_option(option:String) -> void:
 	var option_button:Button = OptionButtonScene.instance() as Button
 	option_button.connect("ready", self, "emit_signal", ["option_added", option_button])
 	option_button.connect("pressed", self, "_on_OptionButton_pressed", [option])
-	option_button.connect("pressed", self, "remove_options")
 	option_button.text = option
 	add_child(option_button)
 
 
 func _on_OptionButton_pressed(option:String) -> void:
+	remove_options()
 	emit_signal("option_selected", option)
 
 


### PR DESCRIPTION
Fixes #54 
This commit contains suggested solution by @Hot-Cuddleccino
where the remove options is called in the function signal handler
instead of being called in the signal itself.