### PR TITLE
Add character editor to inspector script

### DIFF
--- a/addons/textalog/resources/character_class/character_class.gd
+++ b/addons/textalog/resources/character_class/character_class.gd
@@ -13,22 +13,23 @@ class_name Character, "res://addons/textalog/assets/icons/character_icon.png"
 ##
 
 ## Name of the character.
-export(String) var name:String = "" setget set_name
+var name:String = "" setget set_name
 
 ## Name of the character that'll be displayed in game. By default, is the same as name
-export(String) var display_name:String = "" setget set_display_name,get_display_name
+var display_name:String = "" setget set_display_name,get_display_name
+var _display_name:String = "" setget set_display_name
 
 ## Color of the character name
 export(Color) var color:Color = Color.white setget set_color
 
 ## Character icon. Used by the editor.
-export(Texture) var icon:Texture = null setget set_icon
+export(Texture) var icon:Texture setget set_icon
 
 ## Character sounds when talking.
-var blip_sounds:Array = []
+var blip_sounds:Array = [] setget _set_blip_sounds
 
 ## Collection of portraits that'll be displayed in game
-var portraits:Array = []
+var portraits:Array = [] setget _set_portraits
 
 func _init() -> void:
 	portraits = []
@@ -66,6 +67,8 @@ func remove_blip_sound(blip_sound:AudioStream) -> void:
 
 func set_name(value:String) -> void:
 	name = value
+	resource_name = value
+	property_list_changed_notify()
 	emit_changed()
 
 
@@ -84,6 +87,11 @@ func set_icon(value:Texture) -> void:
 	icon = value
 	emit_changed()
 
+func _set_blip_sounds(value:Array) -> void:
+	blip_sounds = value.duplicate()
+	emit_changed()
+	property_list_changed_notify()
+
 
 func get_display_name() -> String:
 	if display_name:
@@ -93,24 +101,40 @@ func get_display_name() -> String:
 
 
 func _get_property_list() -> Array:
-	var properties:Array = []
-	properties.append(
-		{
-			"name":"portraits",
-			"type":TYPE_ARRAY,
-			"usage":PROPERTY_USAGE_SCRIPT_VARIABLE | PROPERTY_USAGE_NOEDITOR,
-		}
-		)
-	properties.append(
-		{
-			"name":"blip_sounds",
-			"type":TYPE_ARRAY,
-			"usage":PROPERTY_USAGE_SCRIPT_VARIABLE | PROPERTY_USAGE_NOEDITOR,
-		}
-	)
-	return properties
+	var p:Array = []
+	var default_usage := PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_SCRIPT_VARIABLE
+	p.append({"type":TYPE_STRING, "name":"name", "usage":default_usage, "hint":PROPERTY_HINT_PLACEHOLDER_TEXT, "hint_string":name})
+	p.append({"type":TYPE_STRING, "name":"_display_name", "usage":default_usage, "hint":PROPERTY_HINT_PLACEHOLDER_TEXT, "hint_string":name})
+	p.append({"type":TYPE_ARRAY, "name":"blip_sounds", "usage":default_usage, "hint":24, "hint_string":"17/17:AudioStream"})
+	
+	p.append({"type":TYPE_NIL, "name":"Portraits", "usage":PROPERTY_USAGE_CATEGORY})
+	p.append({"type":TYPE_ARRAY,"name":"portraits","usage":default_usage, "hint":24, "hint_string":"17/17:Resource"})
+	return p
+
+
+func _set_portraits(value:Array) -> void:
+	portraits = value.duplicate()
+	emit_changed()
+	property_list_changed_notify()
 
 
 func _get(property: String):
 	if property == "portraits_number":
 		return portraits.size()
+
+
+func _hide_script_from_inspector():
+	return true
+
+
+func property_can_revert(property:String) -> bool:
+	var _r_p = ["display_name", "blip_sounds", "portraits"]
+	return property in _r_p
+
+
+func property_get_revert(property:String):
+	match property:
+		"display_name":
+			return ""
+		"blip_sounds", "portraits":
+			return []

--- a/addons/textalog/resources/portrait_class/portrait_class.gd
+++ b/addons/textalog/resources/portrait_class/portrait_class.gd
@@ -12,7 +12,7 @@ export(String) var name:String = "" setget _set_name
 export(Texture) var image:Texture = null setget set_image
 
 ## Optional icon to be used in the editor
-export(Texture) var icon:Texture = null setget _set_icon
+export(Texture) var icon:Texture = load("res://addons/textalog/assets/icons/event_icons/change_expression.png") setget _set_icon
 
 
 func set_image(value:Texture) -> void:
@@ -32,3 +32,7 @@ func _set_name(value:String) -> void:
 	resource_name = value
 	emit_changed()
 	property_list_changed_notify()
+
+
+func _hide_script_from_inspector():
+	return true


### PR DESCRIPTION
This commit adds all the functionality (because I forgot to make multiple commits)
so let me explain what is done here:

- Inspector is filled with the Character class data and its modifiers.
Those modifies the way that `portraits` are displayed, appending them to a
ItemList node.
- The inspector will display a preview of the portrait
- Character class will hide the script from inspector
- Portrait class will hide the script from inspector

Fixes #24 