### PR TITLE
Reuse the already created node in `PortraitManager.add_portrait` and avoid removing the portrait in `CharacterJoin`

### DIFF
--- a/addons/textalog/events/character/join.gd
+++ b/addons/textalog/events/character/join.gd
@@ -62,7 +62,7 @@ func _execute() -> void:
 	]
 	
 	if remove_other_portraits:
-		portrait_manager.remove_all_portraits()
+		portrait_manager.remove_all_other_portraits(character)
 	
 	portrait_manager.call_deferred("callv", "add_portrait", args)
 

--- a/addons/textalog/nodes/dialogue_base_node/portraits_node/portraits_node.gd
+++ b/addons/textalog/nodes/dialogue_base_node/portraits_node/portraits_node.gd
@@ -49,7 +49,7 @@ func add_portrait(
 		_texture_rect = portraits.get(character, null)
 		changed = true
 	# Create a new node as no previous node exists
-	else:
+	if not is_instance_valid(_texture_rect):
 		_texture_rect = TextureRect.new()
 		portraits[character] = _texture_rect
 

--- a/addons/textalog/nodes/dialogue_base_node/portraits_node/portraits_node.gd
+++ b/addons/textalog/nodes/dialogue_base_node/portraits_node/portraits_node.gd
@@ -42,12 +42,10 @@ func add_portrait(
 	
 	
 	var _texture_rect:TextureRect
-	var changed: bool = false
 
 	# Use previous node as reference
 	if character in portraits:
 		_texture_rect = portraits.get(character, null)
-		changed = true
 	# Create a new node as no previous node exists
 	if not is_instance_valid(_texture_rect):
 		_texture_rect = TextureRect.new()
@@ -63,6 +61,8 @@ func add_portrait(
 	_texture_rect.mouse_filter = MOUSE_FILTER_IGNORE
 	_texture_rect.focus_mode = Control.FOCUS_NONE
 	
+	if _texture_rect.get_parent():
+		_texture_rect.get_parent().remove_child(_texture_rect)
 	add_child(_texture_rect)
 	
 	# I know that I can iterate over property list to copy property values
@@ -111,10 +111,7 @@ func add_portrait(
 	
 	grab_portrait_focus(_texture_rect)
 	
-	if changed:
-		emit_signal("portrait_changed", character, portrait)
-	else:
-		emit_signal("portrait_added", character, portrait)
+	emit_signal("portrait_added", character, portrait)
 		
 
 

--- a/addons/textalog/nodes/dialogue_base_node/portraits_node/portraits_node.gd
+++ b/addons/textalog/nodes/dialogue_base_node/portraits_node/portraits_node.gd
@@ -40,18 +40,24 @@ func add_portrait(
 		emit_signal("portrait_added", character, portrait)
 		return
 	
-	# Remove previous node
+	
+	var _texture_rect:TextureRect
+	
+	# Use previous node as reference
 	if character in portraits:
+		_texture_rect = portraits.get(character, null)
 		remove_portrait(character)
 		emit_signal("portrait_changed", character, portrait)
-	
-	var _texture_rect:TextureRect = TextureRect.new()
-	connect("tree_exiting", _texture_rect, "queue_free")
+	# Create a new node as no previous node exists
+	else:
+		_texture_rect = TextureRect.new()
+		portraits[character] = _texture_rect
+
+	if not is_connected("tree_exiting", _texture_rect, "queue_free"):
+		connect("tree_exiting", _texture_rect, "queue_free")
 	
 	if character.display_name:
 		_texture_rect.name = character.display_name
-	
-	portraits[character] = _texture_rect
 	
 	# Focus and _input
 	_texture_rect.mouse_filter = MOUSE_FILTER_IGNORE
@@ -121,6 +127,13 @@ func remove_portrait(character:Character) -> void:
 func remove_all_portraits() -> void:
 	for character in portraits.keys():
 		remove_portrait(character)
+
+
+func remove_all_other_portraits(character:Character) -> void:
+	for _character in portraits.keys():
+		if _character == character:
+			continue
+		remove_portrait(_character)
 
 
 func change_portrait(character:Character, portrait:Portrait) -> void:

--- a/addons/textalog/nodes/dialogue_base_node/portraits_node/portraits_node.gd
+++ b/addons/textalog/nodes/dialogue_base_node/portraits_node/portraits_node.gd
@@ -42,12 +42,12 @@ func add_portrait(
 	
 	
 	var _texture_rect:TextureRect
-	
+	var changed: bool = false
+
 	# Use previous node as reference
 	if character in portraits:
 		_texture_rect = portraits.get(character, null)
-		remove_portrait(character)
-		emit_signal("portrait_changed", character, portrait)
+		changed = true
 	# Create a new node as no previous node exists
 	else:
 		_texture_rect = TextureRect.new()
@@ -111,7 +111,11 @@ func add_portrait(
 	
 	grab_portrait_focus(_texture_rect)
 	
-	emit_signal("portrait_added", character, portrait)
+	if changed:
+		emit_signal("portrait_changed", character, portrait)
+	else:
+		emit_signal("portrait_added", character, portrait)
+		
 
 
 func remove_portrait(character:Character) -> void:


### PR DESCRIPTION
PortraitManager: do not remove portrait of self if:
- it detects we already have a portrait on the scene
- if remove_other_portraits is set

To remove portrait of self, remove_portrait must explicitly be called instead.
For join event, you can clear all portraits if you tick "remove_other_portraits" and do not provide a character.